### PR TITLE
Fix PendingDeprecationWarning in xonsh 0.5.1

### DIFF
--- a/xontrib/powerline.xsh
+++ b/xontrib/powerline.xsh
@@ -30,8 +30,8 @@ def cwd_sec():
 
 
 def branch_sec():
-    if $FORMATTER_DICT['curr_branch']():
-        return Section(' {curr_branch} ', '#333', $FORMATTER_DICT['branch_bg_color']()[1+len('background_'):-1])
+    if $PROMPT_FIELDS['curr_branch']():
+        return Section(' {curr_branch} ', '#333', $PROMPT_FIELDS['branch_bg_color']()[1+len('background_'):-1])
 
 
 def virtualenv_sec():


### PR DESCRIPTION
FORMATTER_DICT is deprecated since xonsh 0.5.1, so there's an annoying warning on every shell update:
```
PendingDeprecationWarning: FORMATTER_DICT is an alias of PROMPT_FIELDS and will be removed in the next release
```

This small change switches to the new PROMPT_FIELDS to resolve this issue.